### PR TITLE
Fix .properties/env variables load, docker images, compose

### DIFF
--- a/docker-dev/Dockerfile
+++ b/docker-dev/Dockerfile
@@ -4,26 +4,26 @@ MAINTAINER CoNWeT Lab. Universidad Politécnica de Madrid
 
 ENV VERSION develop
 
-RUN apt-get update && apt-get install -y python2.7 git maven python-pip mysql-client openjdk-8-jdk wget unzip && \
+RUN apt-get update && apt-get install -y python2.7 git maven python-pip mysql-client openjdk-8-jdk wget unzip git && \
     pip install sh && \
     wget http://download.java.net/glassfish/4.1/release/glassfish-4.1.zip && \
     unzip glassfish-4.1.zip && \
     wget http://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-5.1.39.tar.gz && \
     tar -xvf mysql-connector-java-5.1.39.tar.gz && \
-    cp ./mysql-connector-java-5.1.39/mysql-connector-java-5.1.39-bin.jar glassfish4/glassfish/domains/domain1/lib
-#    git clone https://github.com/FIWARE-TMForum/business-ecosystem-rss.git
-#    git clone https://github.com/samgh96/business-ecosystem-rss.git
+    cp ./mysql-connector-java-5.1.39/mysql-connector-java-5.1.39-bin.jar glassfish4/glassfish/domains/domain1/lib && \
+    git clone https://github.com/FIWARE-TMForum/business-ecosystem-rss.git
+
 
 VOLUME /business-ecosystem-rss
 
 WORKDIR business-ecosystem-rss
 
-# RUN git checkout $VERSION
+RUN git checkout $VERSION
 
-# RUN mvn install -DskipTests && \
-#   mkdir /etc/default/rss/
+RUN mvn install -DskipTests && \
+  mkdir /etc/default/rss/
 
-RUN mkdir /etc/default/rss/
+# RUN mkdir /etc/default/rss/
 
 # Set volume for property files
 VOLUME /etc/default/rss

--- a/docker-dev/docker-compose.yml
+++ b/docker-dev/docker-compose.yml
@@ -1,8 +1,8 @@
 version: '3'
 
 services:
-    rss_db:
-        image: mysql:latest
+    mysql:
+        image: mysql:5.7
         ports:
             - "3333:3306"
         volumes:
@@ -10,16 +10,25 @@ services:
         environment:
             - MYSQL_ROOT_PASSWORD=my-secret-pw
             - MYSQL_DATABASE=RSS
-
     rss:
-        image: rss
+        image: rss-dev
         ports:
             - "9999:8080"
             - "4444:4848"
             - "1111:8181"
         links:
-            - rss_db
+            - mysql
         depends_on:
-            - rss_db
+            - mysql
         volumes:
             - ./rss-config:/etc/default/rss
+        environment:
+            - MYSQL_HOST=mysql
+            - MYSQL_PORT=3306
+            - BAE_RSS_DATABASE_URL=jdbc:mysql://mysql:3306/RSS
+            - BAE_RSS_DATABASE_USERNAME=root
+            - BAE_RSS_DATABASE_PASSWORD=my-secret-pw
+            - BAE_RSS_DATABASE_DRIVERCLASSNAME=com.mysql.jdbc.Driver
+            - BAE_RSS_OAUTH_CONFIG_GRANTEDROLE=admin
+            - BAE_RSS_OAUTH_CONFIG_SELLERROLE=Seller
+            - BAE_RSS_OAUTH_CONFIG_AGGREGATORROLE=Aggregator

--- a/docker-dev/rss-config/database.properties
+++ b/docker-dev/rss-config/database.properties
@@ -1,0 +1,4 @@
+database.url=jdbc:mysql://mysql:3306/RSS
+database.username=root
+database.password=my-secret-pw
+database.driverClassName=com.mysql.jdbc.Driver

--- a/docker-dev/rss-config/oauth.properties
+++ b/docker-dev/rss-config/oauth.properties
@@ -1,0 +1,4 @@
+############## IDM configuration ################
+config.grantedRole=Provider
+config.sellerRole=Seller
+config.aggregatorRole=aggregator

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,9 +2,9 @@ FROM ubuntu:16.04
 
 MAINTAINER CoNWeT Lab. Universidad Politécnica de Madrid
 
-ENV VERSION develop
+ENV VERSION master
 
-RUN apt-get update && apt-get install -y python2.7 git maven python-pip mysql-client openjdk-8-jdk wget unzip && \
+RUN apt-get update && apt-get install -y python2.7 git maven python-pip mysql-client openjdk-8-jdk wget unzip git && \
     pip install sh && \
     wget http://download.java.net/glassfish/4.1/release/glassfish-4.1.zip && \
     unzip glassfish-4.1.zip && \

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,8 +1,8 @@
 version: '3'
 
 services:
-    rss_db:
-        image: mysql:latest
+    mysql:
+        image: mysql:5.7
         ports:
             - "3333:3306"
         volumes:
@@ -12,15 +12,15 @@ services:
             - MYSQL_DATABASE=RSS
 
     rss:
-        image: rss
+        image: fiware/biz-ecosystem-rss:master
         ports:
             - "9999:8080"
             - "4444:4848"
             - "1111:8181"
         links:
-            - rss_db
+            - mysql
         depends_on:
-            - rss_db
+            - mysql
         volumes:
             - ./rss-config:/etc/default/rss
         environment:

--- a/docker/rss-config/database.properties
+++ b/docker/rss-config/database.properties
@@ -1,4 +1,4 @@
-database.url=jdbc:mysql://rss_db:3306/RSS
+database.url=jdbc:mysql://mysql:3306/RSS
 database.username=root
 database.password=my-secret-pw
 database.driverClassName=com.mysql.jdbc.Driver

--- a/rss-core/rss-common/src/main/java/es/upm/fiware/rss/common/properties/AppProperties.java
+++ b/rss-core/rss-common/src/main/java/es/upm/fiware/rss/common/properties/AppProperties.java
@@ -119,7 +119,9 @@ public class AppProperties {
 	    prop.setProperty("config.grantedRole", System.getenv("BAE_RSS_OAUTH_CONFIG_GRANTEDROLE"));
 	    prop.setProperty("config.sellerRole", System.getenv("BAE_RSS_OAUTH_CONFIG_SELLERROLE"));
 	    prop.setProperty("config.aggregatorRole", System.getenv("BAE_RSS_OAUTH_CONFIG_AGGREGATORROLE"));
-	} else {
+	}
+
+	if (filename.equals("/etc/default/rss/oauth.properties")) {
 	    prop.setProperty("database.url", System.getenv("BAE_RSS_DATABASE_URL"));
 	    prop.setProperty("database.username", System.getenv("BAE_RSS_DATABASE_USERNAME"));
 	    prop.setProperty("database.password", System.getenv("BAE_RSS_DATABASE_PASSWORD"));

--- a/rss-core/rss-common/src/main/java/es/upm/fiware/rss/common/properties/AppProperties.java
+++ b/rss-core/rss-common/src/main/java/es/upm/fiware/rss/common/properties/AppProperties.java
@@ -121,7 +121,7 @@ public class AppProperties {
 	    prop.setProperty("config.aggregatorRole", System.getenv("BAE_RSS_OAUTH_CONFIG_AGGREGATORROLE"));
 	}
 
-	if (filename.equals("/etc/default/rss/oauth.properties")) {
+	if (filename.equals("/etc/default/rss/database.properties")) {
 	    prop.setProperty("database.url", System.getenv("BAE_RSS_DATABASE_URL"));
 	    prop.setProperty("database.username", System.getenv("BAE_RSS_DATABASE_USERNAME"));
 	    prop.setProperty("database.password", System.getenv("BAE_RSS_DATABASE_PASSWORD"));


### PR DESCRIPTION
This PR fixes the .properties load error noted in #14 (there was an improper envvar load for database properties). Also, now default environment variables are included in all docker-compose files, the mysql version in those is reverted to 5.7 (not sure why but latest gave me a lot of trouble) and the production-ready docker now uses the master branch instead of develop.